### PR TITLE
Switch to Oracle JDBC configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,17 +34,16 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webflux</artifactId>
-		</dependency>
-
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.40</version>
-            <scope>provided</scope>
-        </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-webflux</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <version>1.18.40</version>
+                        <scope>provided</scope>
+                </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -56,32 +55,24 @@
 			<scope>test</scope>
 		</dependency>
 
-        <!-- R2DBC (Oracle) -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-r2dbc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.oracle.database.r2dbc</groupId>
-            <artifactId>oracle-r2dbc</artifactId>
-            <version>1.3.0</version>
-        </dependency>
-
-
-
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-tx</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-r2dbc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.github.resilience4j</groupId>
-            <artifactId>resilience4j-spring-boot3</artifactId>
-            <version>2.3.0</version>
-        </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-data-jpa</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>com.oracle.database.jdbc</groupId>
+                        <artifactId>ojdbc11</artifactId>
+                        <version>23.4.0.24.05</version>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-tx</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>io.github.resilience4j</groupId>
+                        <artifactId>resilience4j-spring-boot3</artifactId>
+                        <version>2.3.0</version>
+                </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/config/TxConfig.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/config/TxConfig.java
@@ -1,22 +1,22 @@
 package com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.config;
 
-import io.r2dbc.spi.ConnectionFactory;
+import jakarta.persistence.EntityManagerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.r2dbc.connection.R2dbcTransactionManager;
-import org.springframework.transaction.ReactiveTransactionManager;
-import org.springframework.transaction.reactive.TransactionalOperator;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Configuration
 public class TxConfig {
 
     @Bean
-    public ReactiveTransactionManager r2dbcTxManager(ConnectionFactory cf) {
-        return new R2dbcTransactionManager(cf);
+    public PlatformTransactionManager transactionManager(EntityManagerFactory entityManagerFactory) {
+        return new JpaTransactionManager(entityManagerFactory);
     }
 
     @Bean
-    public TransactionalOperator transactionalOperator(ReactiveTransactionManager tm) {
-        return TransactionalOperator.create(tm);
+    public TransactionTemplate transactionTemplate(PlatformTransactionManager transactionManager) {
+        return new TransactionTemplate(transactionManager);
     }
 }

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/exception/GlobalErrorHandler.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/exception/GlobalErrorHandler.java
@@ -20,13 +20,13 @@ import reactor.core.publisher.Mono;
 
 import io.netty.channel.ConnectTimeoutException;
 import io.netty.handler.timeout.ReadTimeoutException;
-import io.r2dbc.spi.R2dbcTimeoutException;
 
 import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
+import java.sql.SQLTimeoutException;
 
 /**
  * Handler global de errores.
@@ -210,7 +210,7 @@ public class GlobalErrorHandler implements ErrorWebExceptionHandler {
 
     private boolean isTimeout(Throwable ex) {
         return findCause(ex, TimeoutException.class) != null
-                || findCause(ex, R2dbcTimeoutException.class) != null
+                || findCause(ex, SQLTimeoutException.class) != null
                 || findCause(ex, SocketTimeoutException.class) != null
                 || findCause(ex, ReadTimeoutException.class) != null
                 || findCause(ex, ConnectTimeoutException.class) != null;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,15 +1,18 @@
 spring.application.name=authorizer-catalog-bin-manager-cf
 
-# R2DBC Oracle por SID (PRORA19)
-spring.r2dbc.url=r2dbc:oracle://?oracle.r2dbc.descriptor=(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=172.27.1.237)(PORT=1191))(CONNECT_DATA=(SID=PRORA19)))
-spring.r2dbc.username=AUTORIZADOR_MARCA_PRIVADA
-spring.r2dbc.password=StR0ng!Pw#2025A
-spring.r2dbc.pool.enabled=true
-# Pool tuning
-spring.r2dbc.pool.initial-size=1
-spring.r2dbc.pool.validation-query=SELECT 1 FROM DUAL
-spring.r2dbc.pool.max-idle-time=PT10M
-spring.r2dbc.pool.max-life-time=PT45M
-spring.r2dbc.pool.max-acquire-time=PT5S
-spring.r2dbc.pool.max-create-connection-time=PT10S
-spring.r2dbc.pool.acquire-retry=1
+# Oracle JDBC configuration
+spring.datasource.url=jdbc:oracle:thin:@172.27.1.237:1191:PRORA19
+spring.datasource.username=AUTORIZADOR_MARCA_PRIVADA
+spring.datasource.password=StR0ng!Pw#2025A
+spring.datasource.driver-class-name=oracle.jdbc.OracleDriver
+spring.datasource.hikari.minimum-idle=1
+spring.datasource.hikari.connection-test-query=SELECT 1 FROM DUAL
+spring.datasource.hikari.idle-timeout=PT10M
+spring.datasource.hikari.max-lifetime=PT45M
+spring.datasource.hikari.connection-timeout=PT5S
+spring.datasource.hikari.initialization-fail-timeout=10000
+
+# JPA configuration aligned with Oracle
+spring.jpa.database-platform=org.hibernate.dialect.OracleDialect
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.open-in-view=false

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -8,8 +8,8 @@
         </encoder>
     </appender>
 
-    <logger name="org.springframework.r2dbc.core.DefaultDatabaseClient" level="DEBUG"/>
-    <logger name="io.r2dbc" level="INFO"/>
+    <logger name="org.springframework.jdbc.core.JdbcTemplate" level="DEBUG"/>
+    <logger name="org.hibernate.SQL" level="DEBUG"/>
     <logger name="oracle" level="INFO"/>
 
     <root level="INFO">


### PR DESCRIPTION
## Summary
- replace the Oracle R2DBC dependencies with Spring Data JPA plus the JDBC driver
- repoint the application properties to `spring.datasource`/`spring.jpa` keys for the Oracle instance
- expose a `JpaTransactionManager`/`TransactionTemplate` and retarget logging towards JDBC instrumentation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfeba88acc832eb8a53c3deed79618