### PR TITLE
Refactor blocking persistence with shared executor

### DIFF
--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/agency/use_case/CreateAgencyService.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/agency/use_case/CreateAgencyService.java
@@ -6,14 +6,14 @@ import com.credibanco.authorizer_catalog_bin_manager_cf.application.agency.port.
 import com.credibanco.authorizer_catalog_bin_manager_cf.domain.agency.Agency;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingTransactionExecutor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Mono;
 
 @Slf4j
 public record CreateAgencyService(AgencyRepository repo,
                                   SubtypeReadOnlyRepository subtypeRepo,
-                                  TransactionalOperator tx) implements CreateAgencyUseCase {
+                                  BlockingTransactionExecutor txExecutor) implements CreateAgencyUseCase {
 
     private static long ms(long t0) { return (System.nanoTime()-t0)/1_000_000; }
 
@@ -22,19 +22,20 @@ public record CreateAgencyService(AgencyRepository repo,
         long t0 = System.nanoTime();
         log.debug("UC:Agency:Create:start st={} ag={}", draft.subtypeCode(), draft.agencyCode());
 
-        return subtypeRepo.existsByCode(draft.subtypeCode())
-                .flatMap(exists -> exists
-                        ? repo.existsByPk(draft.subtypeCode(), draft.agencyCode())
-                        .flatMap(dup -> dup
-                                ? Mono.error(new AppException(AppError.AGENCY_ALREADY_EXISTS,
-                                "subtypeCode=" + draft.subtypeCode() + ", agencyCode=" + draft.agencyCode()))
-                                : repo.save(draft))
-                        : Mono.error(new AppException(AppError.SUBTYPE_NOT_FOUND,
-                        "subtypeCode=" + draft.subtypeCode())))
-                .onErrorMap(IllegalArgumentException.class,
-                        e -> new AppException(AppError.AGENCY_INVALID_DATA, e.getMessage()))
+        return txExecutor.executeMono(() ->
+                        subtypeRepo.existsByCode(draft.subtypeCode())
+                                .flatMap(exists -> exists
+                                        ? repo.existsByPk(draft.subtypeCode(), draft.agencyCode())
+                                        .flatMap(dup -> dup
+                                                ? Mono.error(new AppException(AppError.AGENCY_ALREADY_EXISTS,
+                                                "subtypeCode=" + draft.subtypeCode() + ", agencyCode=" + draft.agencyCode()))
+                                                : repo.save(draft))
+                                        : Mono.error(new AppException(AppError.SUBTYPE_NOT_FOUND,
+                                        "subtypeCode=" + draft.subtypeCode())))
+                                .onErrorMap(IllegalArgumentException.class,
+                                        e -> new AppException(AppError.AGENCY_INVALID_DATA, e.getMessage()))
+                )
                 .doOnSuccess(a -> log.info("UC:Agency:Create:done st={} ag={} status={} elapsedMs={}",
-                        a.subtypeCode(), a.agencyCode(), a.status(), ms(t0)))
-                .as(tx::transactional);
+                        a.subtypeCode(), a.agencyCode(), a.status(), ms(t0)));
     }
 }

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/agency/use_case/UpdateAgencyService.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/agency/use_case/UpdateAgencyService.java
@@ -6,14 +6,14 @@ import com.credibanco.authorizer_catalog_bin_manager_cf.application.agency.port.
 import com.credibanco.authorizer_catalog_bin_manager_cf.domain.agency.Agency;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingTransactionExecutor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Mono;
 
 @Slf4j
 public record UpdateAgencyService(AgencyRepository repo,
                                   SubtypeReadOnlyRepository subtypeRepo,
-                                  TransactionalOperator tx) implements UpdateAgencyUseCase {
+                                  BlockingTransactionExecutor txExecutor) implements UpdateAgencyUseCase {
 
     private static long ms(long t0) { return (System.nanoTime()-t0)/1_000_000; }
 
@@ -22,42 +22,43 @@ public record UpdateAgencyService(AgencyRepository repo,
         long t0 = System.nanoTime();
         log.debug("UC:Agency:Update:start st={} ag={}", updated.subtypeCode(), updated.agencyCode());
 
-        return subtypeRepo.existsByCode(updated.subtypeCode())
-                .flatMap(exists -> exists
-                        ? repo.findByPk(updated.subtypeCode(), updated.agencyCode())
-                        : Mono.error(new AppException(AppError.SUBTYPE_NOT_FOUND))
+        return txExecutor.executeMono(() ->
+                        subtypeRepo.existsByCode(updated.subtypeCode())
+                                .flatMap(exists -> exists
+                                        ? repo.findByPk(updated.subtypeCode(), updated.agencyCode())
+                                        : Mono.error(new AppException(AppError.SUBTYPE_NOT_FOUND))
+                                )
+                                .switchIfEmpty(Mono.error(new AppException(AppError.AGENCY_NOT_FOUND,
+                                        "subtypeCode=" + updated.subtypeCode() + ", agencyCode=" + updated.agencyCode())))
+                                .flatMap(current -> {
+                                    Agency merged;
+                                    try {
+                                        merged = current.updateBasics(
+                                                updated.name(),
+                                                updated.agencyNit(),
+                                                updated.address(),
+                                                updated.phone(),
+                                                updated.municipalityDaneCode(),
+                                                updated.embosserHighlight(),
+                                                updated.embosserPins(),
+                                                updated.cardCustodianPrimary(),
+                                                updated.cardCustodianPrimaryId(),
+                                                updated.cardCustodianSecondary(),
+                                                updated.cardCustodianSecondaryId(),
+                                                updated.pinCustodianPrimary(),
+                                                updated.pinCustodianPrimaryId(),
+                                                updated.pinCustodianSecondary(),
+                                                updated.pinCustodianSecondaryId(),
+                                                updated.description(),
+                                                updated.updatedBy()
+                                        );
+                                    } catch (IllegalArgumentException iae) {
+                                        return Mono.error(new AppException(AppError.AGENCY_INVALID_DATA, iae.getMessage()));
+                                    }
+                                    return repo.save(merged);
+                                })
                 )
-                .switchIfEmpty(Mono.error(new AppException(AppError.AGENCY_NOT_FOUND,
-                        "subtypeCode=" + updated.subtypeCode() + ", agencyCode=" + updated.agencyCode())))
-                .flatMap(current -> {
-                    Agency merged;
-                    try {
-                        merged = current.updateBasics(
-                                updated.name(),
-                                updated.agencyNit(),
-                                updated.address(),
-                                updated.phone(),
-                                updated.municipalityDaneCode(),
-                                updated.embosserHighlight(),
-                                updated.embosserPins(),
-                                updated.cardCustodianPrimary(),
-                                updated.cardCustodianPrimaryId(),
-                                updated.cardCustodianSecondary(),
-                                updated.cardCustodianSecondaryId(),
-                                updated.pinCustodianPrimary(),
-                                updated.pinCustodianPrimaryId(),
-                                updated.pinCustodianSecondary(),
-                                updated.pinCustodianSecondaryId(),
-                                updated.description(),
-                                updated.updatedBy()
-                        );
-                    } catch (IllegalArgumentException iae) {
-                        return Mono.error(new AppException(AppError.AGENCY_INVALID_DATA, iae.getMessage()));
-                    }
-                    return repo.save(merged);
-                })
                 .doOnSuccess(a -> log.info("UC:Agency:Update:done st={} ag={} elapsedMs={}",
-                        a.subtypeCode(), a.agencyCode(), ms(t0)))
-                .as(tx::transactional);
+                        a.subtypeCode(), a.agencyCode(), ms(t0)));
     }
 }

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/plan/use_case/AddPlanItemService.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/plan/use_case/AddPlanItemService.java
@@ -8,8 +8,8 @@ import com.credibanco.authorizer_catalog_bin_manager_cf.domain.plan.CommerceVali
 import com.credibanco.authorizer_catalog_bin_manager_cf.domain.plan.PlanItem;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingTransactionExecutor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -18,40 +18,40 @@ import java.util.*;
 @Slf4j
 public record AddPlanItemService(CommercePlanRepository planRepo,
                                  CommercePlanItemRepository itemRepo,
-                                 TransactionalOperator tx) implements AddPlanItemUseCase {
+                                 BlockingTransactionExecutor txExecutor) implements AddPlanItemUseCase {
 
     private static final int BATCH_SIZE = 500;
 
     @Override
     public Mono<PlanItem> addValue(String planCode, String value, String by) {
         log.info("AddPlanItemService IN planCode={} value={} by={}", planCode, value, by);
-        return planRepo.findByCode(planCode)
-                .switchIfEmpty(Mono.<com.credibanco.authorizer_catalog_bin_manager_cf.domain.plan.CommercePlan>error(
-                        new AppException(AppError.PLAN_NOT_FOUND, "code=" + planCode)))
-                .flatMap(p -> {
-                    // Validación por modo
-                    if (p.validationMode() == CommerceValidationMode.MCC) {
-                        if (value == null || !value.matches("^\\d{4}$")) {
-                            return Mono.<PlanItem>error(new AppException(AppError.PLAN_ITEM_INVALID_DATA,
-                                    "Para modo MCC, 'value' debe ser 4 dígitos"));
-                        }
-                    } else if (p.validationMode() == CommerceValidationMode.MERCHANT_ID) {
-                        if (value == null || !value.matches("^\\d{9}$")) {
-                            return Mono.<PlanItem>error(new AppException(AppError.PLAN_ITEM_INVALID_DATA,
-                                    "Para modo MERCHANT_ID, 'value' debe ser 9 dígitos"));
-                        }
-                    }
-                    return itemRepo.findByValue(p.planId(), value)
-                            .flatMap(existing -> Mono.<PlanItem>error(
-                                    new AppException(AppError.PLAN_ITEM_INVALID_DATA, "Ítem ya existe")))
-                            .switchIfEmpty(
-                                    (p.validationMode() == CommerceValidationMode.MCC)
-                                            ? itemRepo.insertMcc(p.planId(), value, by)
-                                            : itemRepo.insertMerchant(p.planId(), value, by)
-                            );
-                })
+        return txExecutor.executeMono(() ->
+                        planRepo.findByCode(planCode)
+                                .switchIfEmpty(Mono.<com.credibanco.authorizer_catalog_bin_manager_cf.domain.plan.CommercePlan>error(
+                                        new AppException(AppError.PLAN_NOT_FOUND, "code=" + planCode)))
+                                .flatMap(p -> {
+                                    if (p.validationMode() == CommerceValidationMode.MCC) {
+                                        if (value == null || !value.matches("^\\d{4}$")) {
+                                            return Mono.<PlanItem>error(new AppException(AppError.PLAN_ITEM_INVALID_DATA,
+                                                    "Para modo MCC, 'value' debe ser 4 dígitos"));
+                                        }
+                                    } else if (p.validationMode() == CommerceValidationMode.MERCHANT_ID) {
+                                        if (value == null || !value.matches("^\\d{9}$")) {
+                                            return Mono.<PlanItem>error(new AppException(AppError.PLAN_ITEM_INVALID_DATA,
+                                                    "Para modo MERCHANT_ID, 'value' debe ser 9 dígitos"));
+                                        }
+                                    }
+                                    return itemRepo.findByValue(p.planId(), value)
+                                            .flatMap(existing -> Mono.<PlanItem>error(
+                                                    new AppException(AppError.PLAN_ITEM_INVALID_DATA, "Ítem ya existe")))
+                                            .switchIfEmpty(
+                                                    (p.validationMode() == CommerceValidationMode.MCC)
+                                                            ? itemRepo.insertMcc(p.planId(), value, by)
+                                                            : itemRepo.insertMerchant(p.planId(), value, by)
+                                            );
+                                })
+                )
                 .doOnSuccess(pi -> log.info("AddPlanItemService OK planId={} itemId={}", pi.planId(), pi.planItemId()))
-                .as(tx::transactional)
                 .onErrorMap(org.springframework.dao.DuplicateKeyException.class,
                         e -> new AppException(AppError.PLAN_ITEM_INVALID_DATA, "Ítem ya existe"));
     }
@@ -68,59 +68,60 @@ public record AddPlanItemService(CommercePlanRepository planRepo,
                 .distinct()
                 .toList();
 
-        return planRepo.findByCode(planCode)
-                .switchIfEmpty(Mono.<com.credibanco.authorizer_catalog_bin_manager_cf.domain.plan.CommercePlan>error(
-                        new AppException(AppError.PLAN_NOT_FOUND, "code=" + planCode)))
-                .flatMap(plan -> {
-                    var mode = plan.validationMode();
+        return txExecutor.executeMono(() ->
+                        planRepo.findByCode(planCode)
+                                .switchIfEmpty(Mono.<com.credibanco.authorizer_catalog_bin_manager_cf.domain.plan.CommercePlan>error(
+                                        new AppException(AppError.PLAN_NOT_FOUND, "code=" + planCode)))
+                                .flatMap(plan -> {
+                                    var mode = plan.validationMode();
 
-                    List<String> invalid = cleaned.stream()
-                            .filter(v -> !isValid(mode, v))
-                            .toList();
-                    Set<String> invalidSet = new HashSet<>(invalid);
+                                    List<String> invalid = cleaned.stream()
+                                            .filter(v -> !isValid(mode, v))
+                                            .toList();
+                                    Set<String> invalidSet = new HashSet<>(invalid);
 
-                    List<String> candidates = cleaned.stream()
-                            .filter(v -> !invalidSet.contains(v))
-                            .toList();
+                                    List<String> candidates = cleaned.stream()
+                                            .filter(v -> !invalidSet.contains(v))
+                                            .toList();
 
-                    return existingValues(plan.planId(), candidates)
-                            .collectList()
-                            .flatMap(existing -> {
-                                Set<String> existingSet = new HashSet<>(existing);
-                                List<String> duplicates = candidates.stream()
-                                        .filter(existingSet::contains)
-                                        .toList();
-                                List<String> toInsert = candidates.stream()
-                                        .filter(v -> !existingSet.contains(v))
-                                        .toList();
+                                    return existingValues(plan.planId(), candidates)
+                                            .collectList()
+                                            .flatMap(existing -> {
+                                                Set<String> existingSet = new HashSet<>(existing);
+                                                List<String> duplicates = candidates.stream()
+                                                        .filter(existingSet::contains)
+                                                        .toList();
+                                                List<String> toInsert = candidates.stream()
+                                                        .filter(v -> !existingSet.contains(v))
+                                                        .toList();
 
-                                if (toInsert.isEmpty()) {
-                                    return Mono.just(new PlanItemsBulkResult(
-                                            plan.code(),
-                                            rawValues == null ? 0 : rawValues.size(),
-                                            0,
-                                            duplicates.size(),
-                                            invalid.size(),
-                                            invalid,
-                                            duplicates
-                                    ));
-                                }
+                                                if (toInsert.isEmpty()) {
+                                                    return Mono.just(new PlanItemsBulkResult(
+                                                            plan.code(),
+                                                            rawValues == null ? 0 : rawValues.size(),
+                                                            0,
+                                                            duplicates.size(),
+                                                            invalid.size(),
+                                                            invalid,
+                                                            duplicates
+                                                    ));
+                                                }
 
-                                return insertBatches(plan.planId(), mode, toInsert, by)
-                                        .map(inserted -> new PlanItemsBulkResult(
-                                                plan.code(),
-                                                rawValues.size(),
-                                                inserted,
-                                                duplicates.size(),
-                                                invalid.size(),
-                                                invalid,
-                                                duplicates
-                                        ));
-                            });
-                })
+                                                return insertBatches(plan.planId(), mode, toInsert, by)
+                                                        .map(inserted -> new PlanItemsBulkResult(
+                                                                plan.code(),
+                                                                rawValues.size(),
+                                                                inserted,
+                                                                duplicates.size(),
+                                                                invalid.size(),
+                                                                invalid,
+                                                                duplicates
+                                                        ));
+                                            });
+                                })
+                )
                 .doOnSuccess(r -> log.info("AddPlanItemService OK (bulk) planCode={} inserted={} dup={} invalid={}",
-                        r.planCode(), r.inserted(), r.duplicates(), r.invalid()))
-                .as(tx::transactional);
+                        r.planCode(), r.inserted(), r.duplicates(), r.invalid()));
     }
 
     private boolean isValid(CommerceValidationMode mode, String v) {

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/plan/use_case/ChangePlanItemStatusService.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/plan/use_case/ChangePlanItemStatusService.java
@@ -6,14 +6,14 @@ import com.credibanco.authorizer_catalog_bin_manager_cf.application.plan.port.ou
 import com.credibanco.authorizer_catalog_bin_manager_cf.domain.plan.PlanItem;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingTransactionExecutor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Mono;
 
 @Slf4j
 public record ChangePlanItemStatusService(CommercePlanRepository planRepo,
                                           CommercePlanItemRepository itemRepo,
-                                          TransactionalOperator tx)
+                                          BlockingTransactionExecutor txExecutor)
         implements ChangePlanItemStatusUseCase {
 
     @Override
@@ -22,14 +22,15 @@ public record ChangePlanItemStatusService(CommercePlanRepository planRepo,
         if (!"A".equals(status) && !"I".equals(status)) {
             return Mono.<PlanItem>error(new AppException(AppError.PLAN_ITEM_INVALID_DATA, "status inválido (A|I)"));
         }
-        return planRepo.findByCode(planCode)
-                .switchIfEmpty(Mono.<com.credibanco.authorizer_catalog_bin_manager_cf.domain.plan.CommercePlan>error(
-                        new AppException(AppError.PLAN_NOT_FOUND)))
-                .flatMap(p -> itemRepo.changeStatus(p.planId(), value, status, updatedBy))
-                .switchIfEmpty(Mono.<PlanItem>error(new AppException(AppError.PLAN_ITEM_NOT_FOUND,
-                        "value=" + value + " en plan " + planCode)))
+        return txExecutor.executeMono(() ->
+                        planRepo.findByCode(planCode)
+                                .switchIfEmpty(Mono.<com.credibanco.authorizer_catalog_bin_manager_cf.domain.plan.CommercePlan>error(
+                                        new AppException(AppError.PLAN_NOT_FOUND)))
+                                .flatMap(p -> itemRepo.changeStatus(p.planId(), value, status, updatedBy))
+                                .switchIfEmpty(Mono.<PlanItem>error(new AppException(AppError.PLAN_ITEM_NOT_FOUND,
+                                        "value=" + value + " en plan " + planCode)))
+                )
                 .doOnSuccess(pi -> log.info("ChangePlanItemStatusService OK planId={} itemId={} status={}",
-                        pi.planId(), pi.planItemId(), status))
-                .as(tx::transactional);
+                        pi.planId(), pi.planItemId(), status));
     }
 }

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/plan/use_case/CreatePlanService.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/plan/use_case/CreatePlanService.java
@@ -6,24 +6,25 @@ import com.credibanco.authorizer_catalog_bin_manager_cf.domain.plan.CommercePlan
 import com.credibanco.authorizer_catalog_bin_manager_cf.domain.plan.CommerceValidationMode;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingTransactionExecutor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Mono;
 
 @Slf4j
-public record CreatePlanService(CommercePlanRepository repo, TransactionalOperator tx)
+public record CreatePlanService(CommercePlanRepository repo, BlockingTransactionExecutor txExecutor)
         implements CreatePlanUseCase {
     @Override
     public Mono<CommercePlan> execute(String code, String name, CommerceValidationMode mode, String description, String by) {
         log.info("CreatePlanService IN code={} name={} mode={} by={}", code, name, mode, by);
-        return repo.existsByCode(code)
-                .flatMap(exists -> exists
-                        ? Mono.<CommercePlan>error(new AppException(AppError.PLAN_ALREADY_EXISTS))
-                        : Mono.fromCallable(() -> CommercePlan.createNew(code, name, mode, description, by))
-                        .onErrorMap(IllegalArgumentException.class,
-                                e -> new AppException(AppError.PLAN_INVALID_DATA, e.getMessage()))
-                        .flatMap(repo::save))
-                .doOnSuccess(p -> log.info("CreatePlanService OK code={} id={}", p.code(), p.planId()))
-                .as(tx::transactional);
+        return txExecutor.executeMono(() ->
+                        repo.existsByCode(code)
+                                .flatMap(exists -> exists
+                                        ? Mono.<CommercePlan>error(new AppException(AppError.PLAN_ALREADY_EXISTS))
+                                        : Mono.fromCallable(() -> CommercePlan.createNew(code, name, mode, description, by))
+                                        .onErrorMap(IllegalArgumentException.class,
+                                                e -> new AppException(AppError.PLAN_INVALID_DATA, e.getMessage()))
+                                        .flatMap(repo::save))
+                )
+                .doOnSuccess(p -> log.info("CreatePlanService OK code={} id={}", p.code(), p.planId()));
     }
 }

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/rule/use_case/ChangeValidationStatusService.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/rule/use_case/ChangeValidationStatusService.java
@@ -5,12 +5,12 @@ import com.credibanco.authorizer_catalog_bin_manager_cf.application.rule.port.ou
 import com.credibanco.authorizer_catalog_bin_manager_cf.domain.rule.Validation;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingTransactionExecutor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Mono;
 
 @Slf4j
-public record ChangeValidationStatusService(ValidationRepository repo, TransactionalOperator tx)
+public record ChangeValidationStatusService(ValidationRepository repo, BlockingTransactionExecutor txExecutor)
         implements ChangeValidationStatusUseCase {
 
     private static long ms(long t0) { return (System.nanoTime()-t0)/1_000_000; }
@@ -21,18 +21,19 @@ public record ChangeValidationStatusService(ValidationRepository repo, Transacti
         if (!"A".equals(newStatus) && !"I".equals(newStatus)) {
             return Mono.error(new AppException(AppError.RULES_VALIDATION_INVALID_DATA, "status debe ser 'A' o 'I'"));
         }
-        return repo.findByCode(code)
-                .switchIfEmpty(Mono.error(new AppException(AppError.RULES_VALIDATION_NOT_FOUND)))
-                .map(cur -> {
-                    try { return cur.changeStatus(newStatus, byNullable); }
-                    catch (IllegalArgumentException iae) {
-                        throw new AppException(AppError.RULES_VALIDATION_INVALID_DATA, iae.getMessage());
-                    }
-                })
-                .flatMap(repo::save)
+        return txExecutor.executeMono(() ->
+                        repo.findByCode(code)
+                                .switchIfEmpty(Mono.error(new AppException(AppError.RULES_VALIDATION_NOT_FOUND)))
+                                .map(cur -> {
+                                    try { return cur.changeStatus(newStatus, byNullable); }
+                                    catch (IllegalArgumentException iae) {
+                                        throw new AppException(AppError.RULES_VALIDATION_INVALID_DATA, iae.getMessage());
+                                    }
+                                })
+                                .flatMap(repo::save)
+                )
                 .doOnSuccess(v -> { long e=(System.nanoTime()-t0)/1_000_000;
                     log.info("UC:Validation:ChangeStatus:done code={} status={} elapsedMs={}", v.code(), v.status(), e);
-                })
-                .as(tx::transactional);
+                });
     }
 }

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/rule/use_case/CreateValidationService.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/rule/use_case/CreateValidationService.java
@@ -6,12 +6,12 @@ import com.credibanco.authorizer_catalog_bin_manager_cf.domain.rule.Validation;
 import com.credibanco.authorizer_catalog_bin_manager_cf.domain.rule.ValidationDataType;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingTransactionExecutor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Mono;
 
 @Slf4j
-public record CreateValidationService(ValidationRepository repo, TransactionalOperator tx)
+public record CreateValidationService(ValidationRepository repo, BlockingTransactionExecutor txExecutor)
         implements CreateValidationUseCase {
 
     private static long ms(long t0) { return (System.nanoTime()-t0)/1_000_000; }
@@ -19,15 +19,16 @@ public record CreateValidationService(ValidationRepository repo, TransactionalOp
     @Override
     public Mono<Validation> execute(String code, String description, ValidationDataType type, String createdByNullable) {
         long t0 = System.nanoTime();
-        return repo.existsByCode(code)
-                .flatMap(exists -> exists
-                        ? Mono.error(new AppException(AppError.RULES_VALIDATION_ALREADY_EXISTS))
-                        : Mono.fromCallable(() -> Validation.createNew(code, description, type, createdByNullable))
-                        .onErrorMap(IllegalArgumentException.class,
-                                e -> new AppException(AppError.RULES_VALIDATION_INVALID_DATA, e.getMessage()))
-                        .flatMap(repo::save)
+        return txExecutor.executeMono(() ->
+                        repo.existsByCode(code)
+                                .flatMap(exists -> exists
+                                        ? Mono.error(new AppException(AppError.RULES_VALIDATION_ALREADY_EXISTS))
+                                        : Mono.fromCallable(() -> Validation.createNew(code, description, type, createdByNullable))
+                                        .onErrorMap(IllegalArgumentException.class,
+                                                e -> new AppException(AppError.RULES_VALIDATION_INVALID_DATA, e.getMessage()))
+                                        .flatMap(repo::save)
+                                )
                 )
-                .doOnSuccess(v -> log.info("UC:Validation:Create:done code={} elapsedMs={}", code, ms(t0)))
-                .as(tx::transactional);
+                .doOnSuccess(v -> log.info("UC:Validation:Create:done code={} elapsedMs={}", code, ms(t0)));
     }
 }

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/subtype/use_case/ChangeSubtypeStatusService.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/subtype/use_case/ChangeSubtypeStatusService.java
@@ -6,15 +6,15 @@ import com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.port
 import com.credibanco.authorizer_catalog_bin_manager_cf.domain.subtype.Subtype;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingTransactionExecutor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Mono;
 
 @Slf4j
 public record ChangeSubtypeStatusService(
         SubtypeRepository repo,
         AgencyReadOnlyRepository agencyRepo,
-        TransactionalOperator tx
+        BlockingTransactionExecutor txExecutor
 ) implements ChangeSubtypeStatusUseCase {
 
     private static long ms(long t0) { return (System.nanoTime() - t0) / 1_000_000; }
@@ -28,24 +28,25 @@ public record ChangeSubtypeStatusService(
             return Mono.error(new AppException(AppError.SUBTYPE_INVALID_DATA, "status debe ser 'A' o 'I'"));
         }
 
-        return repo.findByPk(bin, subtypeCode)
-                .switchIfEmpty(Mono.error(new AppException(AppError.SUBTYPE_NOT_FOUND)))
-                .flatMap(s -> {
-                    if ("A".equals(newStatus)) {
-                        return agencyRepo.countActiveBySubtypeCode(s.subtypeCode())
-                                .flatMap(cnt -> (cnt > 0)
-                                        ? Mono.just(s)
-                                        : Mono.error(new AppException(AppError.SUBTYPE_ACTIVATE_REQUIRES_AGENCY,
-                                        "Para activar SUBTYPE se requiere al menos una AGENCY activa")))
-                                .map(ok -> ok.changeStatus("A", by));
-                    }
-                    return Mono.just(s.changeStatus("I", by));
-                })
-                .onErrorMap(IllegalArgumentException.class,
-                        e -> new AppException(AppError.SUBTYPE_INVALID_DATA, e.getMessage()))
-                .flatMap(repo::save)
+        return txExecutor.executeMono(() ->
+                        repo.findByPk(bin, subtypeCode)
+                                .switchIfEmpty(Mono.error(new AppException(AppError.SUBTYPE_NOT_FOUND)))
+                                .flatMap(s -> {
+                                    if ("A".equals(newStatus)) {
+                                        return agencyRepo.countActiveBySubtypeCode(s.subtypeCode())
+                                                .flatMap(cnt -> (cnt > 0)
+                                                        ? Mono.just(s)
+                                                        : Mono.error(new AppException(AppError.SUBTYPE_ACTIVATE_REQUIRES_AGENCY,
+                                                        "Para activar SUBTYPE se requiere al menos una AGENCY activa")))
+                                                .map(ok -> ok.changeStatus("A", by));
+                                    }
+                                    return Mono.just(s.changeStatus("I", by));
+                                })
+                                .onErrorMap(IllegalArgumentException.class,
+                                        e -> new AppException(AppError.SUBTYPE_INVALID_DATA, e.getMessage()))
+                                .flatMap(repo::save)
+                )
                 .doOnSuccess(s -> log.info("UC:Subtype:ChangeStatus:done bin={} code={} status={} elapsedMs={}",
-                        s.bin(), s.subtypeCode(), s.status(), ms(t0)))
-                .as(tx::transactional);
+                        s.bin(), s.subtypeCode(), s.status(), ms(t0)));
     }
 }

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/config/AgencyUseCaseConfig.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/config/AgencyUseCaseConfig.java
@@ -4,32 +4,32 @@ import com.credibanco.authorizer_catalog_bin_manager_cf.application.agency.port.
 import com.credibanco.authorizer_catalog_bin_manager_cf.application.agency.port.outbound.AgencyRepository;
 import com.credibanco.authorizer_catalog_bin_manager_cf.application.agency.port.outbound.SubtypeReadOnlyRepository;
 import com.credibanco.authorizer_catalog_bin_manager_cf.application.agency.use_case.*;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingTransactionExecutor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
 @Configuration
 public class AgencyUseCaseConfig {
 
     @Bean
     public CreateAgencyUseCase createAgencyUseCase(
-            AgencyRepository repo, SubtypeReadOnlyRepository subtypeRepo, TransactionalOperator tx
-    ) { return new CreateAgencyService(repo, subtypeRepo, tx); }
+            AgencyRepository repo, SubtypeReadOnlyRepository subtypeRepo, BlockingTransactionExecutor txExecutor
+    ) { return new CreateAgencyService(repo, subtypeRepo, txExecutor); }
 
     @Bean
     public UpdateAgencyUseCase updateAgencyUseCase(
             AgencyRepository repo,
             SubtypeReadOnlyRepository subtypeRepo,
-            TransactionalOperator tx
+            BlockingTransactionExecutor txExecutor
     ) {
-        return new UpdateAgencyService(repo, subtypeRepo, tx);
+        return new UpdateAgencyService(repo, subtypeRepo, txExecutor);
     }
 
 
     @Bean
     public ChangeAgencyStatusUseCase changeAgencyStatusUseCase(
-            AgencyRepository repo, SubtypeReadOnlyRepository subtypeRepo, TransactionalOperator tx
-    ) { return new ChangeAgencyStatusService(repo, subtypeRepo, tx); }
+            AgencyRepository repo, SubtypeReadOnlyRepository subtypeRepo, BlockingTransactionExecutor txExecutor
+    ) { return new ChangeAgencyStatusService(repo, subtypeRepo, txExecutor); }
 
     @Bean
     public GetAgencyUseCase getAgencyUseCase(

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/config/BinUseCaseConfig.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/config/BinUseCaseConfig.java
@@ -3,9 +3,9 @@ package com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.config;
 import com.credibanco.authorizer_catalog_bin_manager_cf.application.bin.port.inbound.*;
 import com.credibanco.authorizer_catalog_bin_manager_cf.application.bin.use_case.*;
 import com.credibanco.authorizer_catalog_bin_manager_cf.application.bin.port.outbound.BinRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingTransactionExecutor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
 @Configuration
 public class BinUseCaseConfig {
@@ -14,8 +14,8 @@ public class BinUseCaseConfig {
     GetBinUseCase getBinUseCase(BinRepository repo) { return new GetBinService(repo); }
     @Bean
     ListBinsUseCase listBinsUseCase(BinRepository repo) { return new ListBinsService(repo); }
-    @Bean public CreateBinUseCase createBinUseCase(BinRepository repo, TransactionalOperator tx) { return new CreateBinService(repo, tx); }
-    @Bean public ChangeBinStatusUseCase changeBinStatusUseCase(BinRepository repo, TransactionalOperator tx) { return new ChangeBinStatusService(repo, tx); }
-    @Bean public UpdateBinUseCase updateBinUseCase(BinRepository repo, TransactionalOperator tx) { return new UpdateBinService(repo, tx); }
+    @Bean public CreateBinUseCase createBinUseCase(BinRepository repo, BlockingTransactionExecutor txExecutor) { return new CreateBinService(repo, txExecutor); }
+    @Bean public ChangeBinStatusUseCase changeBinStatusUseCase(BinRepository repo, BlockingTransactionExecutor txExecutor) { return new ChangeBinStatusService(repo, txExecutor); }
+    @Bean public UpdateBinUseCase updateBinUseCase(BinRepository repo, BlockingTransactionExecutor txExecutor) { return new UpdateBinService(repo, txExecutor); }
 
 }

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/config/PlanUseCaseConfig.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/config/PlanUseCaseConfig.java
@@ -5,29 +5,29 @@ import com.credibanco.authorizer_catalog_bin_manager_cf.application.plan.port.ou
 import com.credibanco.authorizer_catalog_bin_manager_cf.application.plan.port.outbound.CommercePlanRepository;
 import com.credibanco.authorizer_catalog_bin_manager_cf.application.plan.port.outbound.SubtypePlanRepository;
 import com.credibanco.authorizer_catalog_bin_manager_cf.application.plan.use_case.*;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingTransactionExecutor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
 @Configuration
 public class PlanUseCaseConfig {
 
-    @Bean CreatePlanUseCase createPlanUseCase(CommercePlanRepository r, TransactionalOperator tx) {
-        return new CreatePlanService(r, tx);
+    @Bean CreatePlanUseCase createPlanUseCase(CommercePlanRepository r, BlockingTransactionExecutor txExecutor) {
+        return new CreatePlanService(r, txExecutor);
     }
 
     @Bean AddPlanItemUseCase addPlanItemUseCase(CommercePlanRepository pr,
                                                 CommercePlanItemRepository ir,
-                                                TransactionalOperator tx) {
-        return new AddPlanItemService(pr, ir, tx);
+                                                BlockingTransactionExecutor txExecutor) {
+        return new AddPlanItemService(pr, ir, txExecutor);
     }
     @Bean
     AssignPlanToSubtypeUseCase assignPlanToSubtypeUseCase(CommercePlanRepository pr,
                                                           SubtypePlanRepository sr,
                                                           com.credibanco.authorizer_catalog_bin_manager_cf.application.plan.port.outbound.SubtypeReadOnlyRepository subtypeRepo,
-                                                          CommercePlanItemRepository itemRepo,  // <— NUEVO
-                                                          TransactionalOperator tx) {
-        return new AssignPlanToSubtypeService(pr, sr, subtypeRepo, itemRepo, tx);
+                                                          CommercePlanItemRepository itemRepo,
+                                                          BlockingTransactionExecutor txExecutor) {
+        return new AssignPlanToSubtypeService(pr, sr, subtypeRepo, itemRepo, txExecutor);
     }
 
     @Bean GetPlanUseCase getPlanUseCase(CommercePlanRepository r) { return new GetPlanService(r); }
@@ -40,8 +40,8 @@ public class PlanUseCaseConfig {
     public ChangePlanItemStatusUseCase changePlanItemStatusUseCase(
             CommercePlanRepository pr,
             CommercePlanItemRepository ir,
-            TransactionalOperator tx
+            BlockingTransactionExecutor txExecutor
     ) {
-        return new ChangePlanItemStatusService(pr, ir, tx);
+        return new ChangePlanItemStatusService(pr, ir, txExecutor);
     }
 }

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/config/RuleUseCaseConfig.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/config/RuleUseCaseConfig.java
@@ -5,18 +5,18 @@ import com.credibanco.authorizer_catalog_bin_manager_cf.application.rule.port.ou
 import com.credibanco.authorizer_catalog_bin_manager_cf.application.rule.port.outbound.ValidationMapRepository;
 import com.credibanco.authorizer_catalog_bin_manager_cf.application.rule.port.outbound.ValidationRepository;
 import com.credibanco.authorizer_catalog_bin_manager_cf.application.rule.use_case.*;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingTransactionExecutor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
 @Configuration
 public class RuleUseCaseConfig {
     @Bean
-    CreateValidationUseCase createValidationUseCase(ValidationRepository r, TransactionalOperator tx) {
-        return new CreateValidationService(r, tx);
+    CreateValidationUseCase createValidationUseCase(ValidationRepository r, BlockingTransactionExecutor txExecutor) {
+        return new CreateValidationService(r, txExecutor);
     }
     @Bean UpdateValidationUseCase updateValidationUseCase(ValidationRepository r) { return new UpdateValidationService(r); }
-    @Bean ChangeValidationStatusUseCase changeValidationStatusUseCase(ValidationRepository r, TransactionalOperator tx) { return new ChangeValidationStatusService(r, tx); }
+    @Bean ChangeValidationStatusUseCase changeValidationStatusUseCase(ValidationRepository r, BlockingTransactionExecutor txExecutor) { return new ChangeValidationStatusService(r, txExecutor); }
     @Bean GetValidationUseCase getValidationUseCase(ValidationRepository r) { return new GetValidationService(r); }
     @Bean ListValidationsUseCase listValidationsUseCase(ValidationRepository r) { return new ListValidationsService(r); }
 
@@ -24,8 +24,8 @@ public class RuleUseCaseConfig {
     MapRuleUseCase mapRuleUseCase(ValidationRepository vr,
                                   ValidationMapRepository mr,
                                   SubtypeReadOnlyRepository sr,
-                                  TransactionalOperator tx) {
-        return new MapRuleService(vr, mr, sr, tx);
+                                  BlockingTransactionExecutor txExecutor) {
+        return new MapRuleService(vr, mr, sr, txExecutor);
     }
 
     @Bean

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/config/SubtypeUseCaseConfig.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/config/SubtypeUseCaseConfig.java
@@ -6,9 +6,9 @@ import com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.port
 import com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.port.outbound.IdTypeReadOnlyRepository;
 import com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.port.outbound.SubtypeRepository;
 import com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.use_case.*;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingTransactionExecutor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
 @Configuration
 public class SubtypeUseCaseConfig {
@@ -18,24 +18,24 @@ public class SubtypeUseCaseConfig {
             SubtypeRepository repo,
             BinReadOnlyRepository binRepo,
             IdTypeReadOnlyRepository idTypeRepo,
-            TransactionalOperator tx
+            BlockingTransactionExecutor txExecutor
     ) {
-        return new CreateSubtypeService(repo, binRepo, idTypeRepo, tx);
+        return new CreateSubtypeService(repo, binRepo, idTypeRepo, txExecutor);
     }
 
     @Bean
     public UpdateSubtypeBasicsUseCase updateSubtypeBasicsUseCase(
-            SubtypeRepository repo, BinReadOnlyRepository binRepo, TransactionalOperator tx
+            SubtypeRepository repo, BinReadOnlyRepository binRepo, BlockingTransactionExecutor txExecutor
     ) {
-        return new UpdateSubtypeBasicsService(repo, binRepo, tx);
+        return new UpdateSubtypeBasicsService(repo, binRepo, txExecutor);
     }
     @Bean
     public ChangeSubtypeStatusUseCase changeSubtypeStatusUseCase(
             SubtypeRepository repo,
             AgencyReadOnlyRepository agencyRepo,
-            TransactionalOperator tx
+            BlockingTransactionExecutor txExecutor
     ) {
-        return new ChangeSubtypeStatusService(repo, agencyRepo, tx);
+        return new ChangeSubtypeStatusService(repo, agencyRepo, txExecutor);
     }
 
     @Bean

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/config/TxConfig.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/config/TxConfig.java
@@ -5,9 +5,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.reactive.ReactiveTransactionManager;
-import org.springframework.transaction.reactive.ReactiveTransactionManagerAdapter;
-import org.springframework.transaction.reactive.TransactionalOperator;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @Configuration
@@ -23,13 +20,4 @@ public class TxConfig {
         return new TransactionTemplate(transactionManager);
     }
 
-    @Bean
-    public ReactiveTransactionManager reactiveTransactionManager(PlatformTransactionManager transactionManager) {
-        return new ReactiveTransactionManagerAdapter(transactionManager);
-    }
-
-    @Bean
-    public TransactionalOperator transactionalOperator(ReactiveTransactionManager reactiveTransactionManager) {
-        return TransactionalOperator.create(reactiveTransactionManager);
-    }
 }

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaAgencyReadOnlyRepository.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaAgencyReadOnlyRepository.java
@@ -2,20 +2,20 @@ package com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.out
 
 import com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.port.outbound.AgencyReadOnlyRepository;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa.repository.AgencyJpaRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingExecutor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 @Repository
 @RequiredArgsConstructor
 public class JpaAgencyReadOnlyRepository implements AgencyReadOnlyRepository {
 
     private final AgencyJpaRepository repository;
+    private final BlockingExecutor blockingExecutor;
 
     @Override
     public Mono<Long> countActiveBySubtypeCode(String subtypeCode) {
-        return Mono.fromCallable(() -> repository.countByIdSubtypeCodeAndStatus(subtypeCode, "A"))
-                .subscribeOn(Schedulers.boundedElastic());
+        return blockingExecutor.mono(() -> repository.countByIdSubtypeCodeAndStatus(subtypeCode, "A"));
     }
 }

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaAgencyRepository.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaAgencyRepository.java
@@ -5,6 +5,7 @@ import com.credibanco.authorizer_catalog_bin_manager_cf.domain.agency.Agency;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa.entity.AgencyEntity;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa.entity.AgencyEntityId;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa.repository.AgencyJpaRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingExecutor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -12,7 +13,6 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 import java.util.List;
 
@@ -21,27 +21,27 @@ import java.util.List;
 public class JpaAgencyRepository implements AgencyRepository {
 
     private final AgencyJpaRepository repository;
+    private final BlockingExecutor blockingExecutor;
 
     @Override
     public Mono<Boolean> existsByPk(String subtypeCode, String agencyCode) {
-        return Mono.fromCallable(() -> repository.existsById(new AgencyEntityId(subtypeCode, agencyCode)))
-                .subscribeOn(Schedulers.boundedElastic());
+        return blockingExecutor.mono(() -> repository.existsById(new AgencyEntityId(subtypeCode, agencyCode)));
     }
 
     @Override
     public Mono<Agency> save(Agency aggregate) {
-        return Mono.fromCallable(() -> {
-                    AgencyEntityId id = new AgencyEntityId(aggregate.subtypeCode(), aggregate.agencyCode());
-                    repository.save(AgencyEntity.fromDomain(aggregate));
-                    return repository.findById(id).map(AgencyEntity::toDomain).orElseThrow();
-                })
-                .subscribeOn(Schedulers.boundedElastic());
+        return blockingExecutor.mono(() -> {
+            AgencyEntityId id = new AgencyEntityId(aggregate.subtypeCode(), aggregate.agencyCode());
+            repository.save(AgencyEntity.fromDomain(aggregate));
+            return repository.findById(id).map(AgencyEntity::toDomain).orElseThrow();
+        });
     }
 
     @Override
     public Mono<Agency> findByPk(String subtypeCode, String agencyCode) {
-        return Mono.defer(() -> Mono.justOrEmpty(repository.findById(new AgencyEntityId(subtypeCode, agencyCode)).map(AgencyEntity::toDomain)))
-                .subscribeOn(Schedulers.boundedElastic());
+        return blockingExecutor.mono(() -> repository.findById(new AgencyEntityId(subtypeCode, agencyCode))
+                .map(AgencyEntity::toDomain)
+                .orElse(null));
     }
 
     @Override
@@ -63,19 +63,17 @@ public class JpaAgencyRepository implements AgencyRepository {
             ));
         }
         Specification<AgencyEntity> finalSpec = spec;
-        return Flux.defer(() -> {
-                    List<Agency> agencies = repository.findAll(finalSpec,
-                                    PageRequest.of(p, s, Sort.by("id.subtypeCode").ascending().and(Sort.by("id.agencyCode").ascending())))
-                            .map(AgencyEntity::toDomain)
-                            .getContent();
-                    return Flux.fromIterable(agencies);
-                })
-                .subscribeOn(Schedulers.boundedElastic());
+        return blockingExecutor.flux(() -> {
+            List<Agency> agencies = repository.findAll(finalSpec,
+                            PageRequest.of(p, s, Sort.by("id.subtypeCode").ascending().and(Sort.by("id.agencyCode").ascending())))
+                    .map(AgencyEntity::toDomain)
+                    .getContent();
+            return agencies;
+        });
     }
 
     @Override
     public Mono<Boolean> existsAnotherActive(String subtypeCode, String excludeAgencyCode) {
-        return Mono.fromCallable(() -> repository.existsAnotherActive(subtypeCode, excludeAgencyCode))
-                .subscribeOn(Schedulers.boundedElastic());
+        return blockingExecutor.mono(() -> repository.existsAnotherActive(subtypeCode, excludeAgencyCode));
     }
 }

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaBinRepository.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaBinRepository.java
@@ -4,13 +4,13 @@ import com.credibanco.authorizer_catalog_bin_manager_cf.application.bin.port.out
 import com.credibanco.authorizer_catalog_bin_manager_cf.domain.bin.Bin;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa.entity.BinEntity;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa.repository.BinJpaRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingExecutor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 import java.util.List;
 
@@ -19,38 +19,36 @@ import java.util.List;
 public class JpaBinRepository implements BinRepository {
 
     private final BinJpaRepository repository;
+    private final BlockingExecutor blockingExecutor;
 
     @Override
     public Mono<Boolean> existsById(String bin) {
-        return Mono.fromCallable(() -> repository.existsById(bin))
-                .subscribeOn(Schedulers.boundedElastic());
+        return blockingExecutor.mono(() -> repository.existsById(bin));
     }
 
     @Override
     public Mono<Bin> save(Bin bin) {
-        return Mono.fromCallable(() -> {
-                    repository.save(BinEntity.fromDomain(bin));
-                    return repository.findById(bin.bin()).map(BinEntity::toDomain).orElseThrow();
-                })
-                .subscribeOn(Schedulers.boundedElastic());
+        return blockingExecutor.mono(() -> {
+            repository.save(BinEntity.fromDomain(bin));
+            return repository.findById(bin.bin()).map(BinEntity::toDomain).orElseThrow();
+        });
     }
 
     @Override
     public Mono<Bin> findById(String bin) {
-        return Mono.defer(() -> Mono.justOrEmpty(repository.findById(bin).map(BinEntity::toDomain)))
-                .subscribeOn(Schedulers.boundedElastic());
+        return blockingExecutor.mono(() ->
+                repository.findById(bin).map(BinEntity::toDomain).orElse(null));
     }
 
     @Override
     public Flux<Bin> findAll(int page, int size) {
         int p = Math.max(0, page);
         int s = Math.max(1, size);
-        return Flux.defer(() -> {
-                    List<Bin> bins = repository.findAll(PageRequest.of(p, s, Sort.by("bin").ascending()))
-                            .map(BinEntity::toDomain)
-                            .getContent();
-                    return Flux.fromIterable(bins);
-                })
-                .subscribeOn(Schedulers.boundedElastic());
+        return blockingExecutor.flux(() -> {
+            List<Bin> bins = repository.findAll(PageRequest.of(p, s, Sort.by("bin").ascending()))
+                    .map(BinEntity::toDomain)
+                    .getContent();
+            return bins;
+        });
     }
 }

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaIdTypeReadOnlyRepository.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaIdTypeReadOnlyRepository.java
@@ -2,20 +2,20 @@ package com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.out
 
 import com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.port.outbound.IdTypeReadOnlyRepository;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa.repository.IdTypeJpaRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingExecutor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 @Repository
 @RequiredArgsConstructor
 public class JpaIdTypeReadOnlyRepository implements IdTypeReadOnlyRepository {
 
     private final IdTypeJpaRepository repository;
+    private final BlockingExecutor blockingExecutor;
 
     @Override
     public Mono<Boolean> existsById(String idType) {
-        return Mono.fromCallable(() -> repository.existsById(idType))
-                .subscribeOn(Schedulers.boundedElastic());
+        return blockingExecutor.mono(() -> repository.existsById(idType));
     }
 }

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaSubtypeReadOnlyRepository.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaSubtypeReadOnlyRepository.java
@@ -1,10 +1,10 @@
 package com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa;
 
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa.repository.SubtypeJpaRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingExecutor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 @Repository
 @RequiredArgsConstructor
@@ -14,22 +14,20 @@ public class JpaSubtypeReadOnlyRepository implements
         com.credibanco.authorizer_catalog_bin_manager_cf.application.rule.port.outbound.SubtypeReadOnlyRepository {
 
     private final SubtypeJpaRepository repository;
+    private final BlockingExecutor blockingExecutor;
 
     @Override
     public Mono<Boolean> isActive(String subtypeCode) {
-        return Mono.fromCallable(() -> repository.existsActiveBySubtypeCode(subtypeCode))
-                .subscribeOn(Schedulers.boundedElastic());
+        return blockingExecutor.mono(() -> repository.existsActiveBySubtypeCode(subtypeCode));
     }
 
     @Override
     public Mono<Boolean> existsByCode(String subtypeCode) {
-        return Mono.fromCallable(() -> repository.existsBySubtypeCode(subtypeCode))
-                .subscribeOn(Schedulers.boundedElastic());
+        return blockingExecutor.mono(() -> repository.existsBySubtypeCode(subtypeCode));
     }
 
     @Override
     public Mono<Boolean> existsByCodeAndBinEfectivo(String code, String binEfectivo) {
-        return Mono.fromCallable(() -> repository.existsBySubtypeCodeAndBin(code, binEfectivo))
-                .subscribeOn(Schedulers.boundedElastic());
+        return blockingExecutor.mono(() -> repository.existsBySubtypeCodeAndBin(code, binEfectivo));
     }
 }

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/util/BlockingExecutor.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/util/BlockingExecutor.java
@@ -1,0 +1,25 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util;
+
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
+@Component
+public class BlockingExecutor {
+
+    public <T> Mono<T> mono(Callable<T> task) {
+        return Mono.fromCallable(() -> Optional.ofNullable(task.call()))
+                .flatMap(optional -> optional.map(Mono::just).orElseGet(Mono::empty))
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    public <T> Flux<T> flux(Callable<Iterable<T>> task) {
+        return Mono.fromCallable(() -> Optional.ofNullable(task.call()))
+                .flatMapMany(optional -> optional.map(Flux::fromIterable).orElseGet(Flux::empty))
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+}

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/util/BlockingTransactionExecutor.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/util/BlockingTransactionExecutor.java
@@ -1,0 +1,32 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionTemplate;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+@Component
+@RequiredArgsConstructor
+public class BlockingTransactionExecutor {
+
+    private final TransactionTemplate transactionTemplate;
+    private final BlockingExecutor blockingExecutor;
+
+    public <T> Mono<T> executeMono(Supplier<Mono<T>> action) {
+        Objects.requireNonNull(action, "action");
+        return blockingExecutor.mono(() ->
+                transactionTemplate.execute(status -> action.get().block()));
+    }
+
+    public <T> Flux<T> executeFlux(Supplier<Flux<T>> action) {
+        Objects.requireNonNull(action, "action");
+        return blockingExecutor.<List<T>>mono(() ->
+                        transactionTemplate.execute(status -> action.get().collectList().block()))
+                .flatMapMany(list -> list == null ? Flux.empty() : Flux.fromIterable(list));
+    }
+}

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/bin/use_case/CreateBinServiceTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/bin/use_case/CreateBinServiceTest.java
@@ -1,0 +1,51 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.application.bin.use_case;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.bin.port.outbound.BinRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.bin.Bin;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingExecutor;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingTransactionExecutor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.transaction.support.ResourcelessTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class CreateBinServiceTest {
+
+    private BinRepository repository;
+    private CreateBinService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = Mockito.mock(BinRepository.class);
+        BlockingExecutor blockingExecutor = new BlockingExecutor();
+        TransactionTemplate template = new TransactionTemplate(new ResourcelessTransactionManager());
+        BlockingTransactionExecutor txExecutor = new BlockingTransactionExecutor(template, blockingExecutor);
+        service = new CreateBinService(repository, txExecutor);
+    }
+
+    @Test
+    void createsBinWhenDoesNotExist() {
+        Mockito.when(repository.existsById("123456")).thenReturn(Mono.just(false));
+        Bin expected = Bin.createNew("123456", "BIN", "DEBITO", "01", null, "desc", "N", null, "me");
+        Mockito.when(repository.save(Mockito.any())).thenReturn(Mono.just(expected));
+
+        StepVerifier.create(service.execute("123456", "BIN", "DEBITO", "01", null, "desc", "N", null, "me"))
+                .expectNext(expected)
+                .verifyComplete();
+
+        Mockito.verify(repository).save(Mockito.any());
+    }
+
+    @Test
+    void failsWhenBinAlreadyExists() {
+        Mockito.when(repository.existsById("123456")).thenReturn(Mono.just(true));
+
+        StepVerifier.create(service.execute("123456", "BIN", "DEBITO", "01", null, "desc", "N", null, "me"))
+                .expectError(AppException.class)
+                .verify();
+    }
+}

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/util/BlockingTransactionExecutorTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/util/BlockingTransactionExecutorTest.java
@@ -1,0 +1,34 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.support.ResourcelessTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class BlockingTransactionExecutorTest {
+
+    private BlockingTransactionExecutor executor;
+
+    @BeforeEach
+    void setUp() {
+        BlockingExecutor blockingExecutor = new BlockingExecutor();
+        TransactionTemplate template = new TransactionTemplate(new ResourcelessTransactionManager());
+        executor = new BlockingTransactionExecutor(template, blockingExecutor);
+    }
+
+    @Test
+    void executeMonoRunsWithinTransaction() {
+        StepVerifier.create(executor.executeMono(() -> Mono.fromCallable(() -> "ok")))
+                .expectNext("ok")
+                .verifyComplete();
+    }
+
+    @Test
+    void executeMonoPropagatesErrors() {
+        StepVerifier.create(executor.executeMono(() -> Mono.error(new IllegalStateException("boom"))))
+                .expectErrorMatches(e -> e instanceof IllegalStateException && "boom".equals(e.getMessage()))
+                .verify();
+    }
+}


### PR DESCRIPTION
## Summary
- introduce reusable BlockingExecutor and BlockingTransactionExecutor to encapsulate boundedElastic calls and transactional blocking
- rework service use cases and configuration to rely on the new executor instead of TransactionalOperator
- update all JPA adapters to use the shared executor and add unit tests for the executor and CreateBinService

## Testing
- `mvn test` *(fails: unable to download Maven parent POM due to 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68dff259c804832ea204538e397a2f97