### PR TITLE
Add explicit BinExtConfig import

### DIFF
--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaBinReadOnlyRepository.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaBinReadOnlyRepository.java
@@ -1,6 +1,7 @@
 package com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa;
 
 import com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.port.outbound.BinReadOnlyRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.port.outbound.BinReadOnlyRepository.BinExtConfig;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa.repository.BinJpaRepository;
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingExecutor;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
## Summary
- add the BinExtConfig import to the JPA read-only repository implementation so the returned Mono uses the correct nested type

## Testing
- mvn test *(fails: cannot download parent POM due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68dffa96e734832ea6c23a2412011151