### PR TITLE
Guard repository specifications and add filter tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,16 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>io.projectreactor</groupId>
-			<artifactId>reactor-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+                <dependency>
+                        <groupId>io.projectreactor</groupId>
+                        <artifactId>reactor-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
 
                 <dependency>
                         <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaCommercePlanRepository.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaCommercePlanRepository.java
@@ -38,16 +38,18 @@ public class JpaCommercePlanRepository implements CommercePlanRepository {
     public Flux<CommercePlan> findAll(String status, String q, int page, int size) {
         int p = Math.max(0, page);
         int s = Math.max(1, size);
-        Specification<CommercePlanEntity> spec = Specification.where(null);
+        Specification<CommercePlanEntity> spec = null;
         if (status != null) {
-            spec = spec.and((root, query, cb) -> cb.equal(root.get("status"), status));
+            Specification<CommercePlanEntity> statusSpec = (root, query, cb) -> cb.equal(root.get("status"), status);
+            spec = Specification.where(statusSpec);
         }
         if (q != null) {
             String like = "%" + q.toUpperCase() + "%";
-            spec = spec.and((root, query, cb) -> cb.or(
+            Specification<CommercePlanEntity> searchSpec = (root, query, cb) -> cb.or(
                     cb.like(cb.upper(root.get("planCode")), like),
                     cb.like(cb.upper(root.get("planName")), like)
-            ));
+            );
+            spec = spec == null ? Specification.where(searchSpec) : spec.and(searchSpec);
         }
         Specification<CommercePlanEntity> finalSpec = spec;
         return blockingExecutor.flux(() -> {

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaSubtypeRepository.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaSubtypeRepository.java
@@ -56,15 +56,18 @@ public class JpaSubtypeRepository implements SubtypeRepository {
     public Flux<Subtype> findAll(String binFilter, String codeFilter, String statusFilter, int page, int size) {
         int p = Math.max(0, page);
         int s = Math.max(1, size);
-        Specification<SubtypeEntity> spec = Specification.where(null);
+        Specification<SubtypeEntity> spec = null;
         if (binFilter != null) {
-            spec = spec.and((root, query, cb) -> cb.equal(root.get("id").get("bin"), binFilter));
+            Specification<SubtypeEntity> binSpec = (root, query, cb) -> cb.equal(root.get("id").get("bin"), binFilter);
+            spec = Specification.where(binSpec);
         }
         if (codeFilter != null) {
-            spec = spec.and((root, query, cb) -> cb.equal(root.get("id").get("subtypeCode"), codeFilter));
+            Specification<SubtypeEntity> codeSpec = (root, query, cb) -> cb.equal(root.get("id").get("subtypeCode"), codeFilter);
+            spec = spec == null ? Specification.where(codeSpec) : spec.and(codeSpec);
         }
         if (statusFilter != null) {
-            spec = spec.and((root, query, cb) -> cb.equal(root.get("status"), statusFilter));
+            Specification<SubtypeEntity> statusSpec = (root, query, cb) -> cb.equal(root.get("status"), statusFilter);
+            spec = spec == null ? Specification.where(statusSpec) : spec.and(statusSpec);
         }
         Specification<SubtypeEntity> finalSpec = spec;
         return blockingExecutor.flux(() -> {

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaValidationMapRepository.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaValidationMapRepository.java
@@ -67,15 +67,18 @@ public class JpaValidationMapRepository implements ValidationMapRepository {
     private Flux<ValidationMap> findByFilters(String subtypeCode, String bin, String status, int page, int size) {
         int p = Math.max(0, page);
         int s = Math.max(1, size);
-        Specification<SubtypeValidationMapEntity> spec = Specification.where(null);
+        Specification<SubtypeValidationMapEntity> spec = null;
         if (subtypeCode != null) {
-            spec = spec.and((root, query, cb) -> cb.equal(root.get("subtypeCode"), subtypeCode));
+            Specification<SubtypeValidationMapEntity> subtypeSpec = (root, query, cb) -> cb.equal(root.get("subtypeCode"), subtypeCode);
+            spec = Specification.where(subtypeSpec);
         }
         if (bin != null) {
-            spec = spec.and((root, query, cb) -> cb.equal(root.get("bin"), bin));
+            Specification<SubtypeValidationMapEntity> binSpec = (root, query, cb) -> cb.equal(root.get("bin"), bin);
+            spec = spec == null ? Specification.where(binSpec) : spec.and(binSpec);
         }
         if (status != null) {
-            spec = spec.and((root, query, cb) -> cb.equal(root.get("status"), status));
+            Specification<SubtypeValidationMapEntity> statusSpec = (root, query, cb) -> cb.equal(root.get("status"), status);
+            spec = spec == null ? Specification.where(statusSpec) : spec.and(statusSpec);
         }
         Specification<SubtypeValidationMapEntity> finalSpec = spec;
         Sort sort = Sort.by("subtypeCode").ascending()

--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaValidationRepository.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaValidationRepository.java
@@ -56,16 +56,18 @@ public class JpaValidationRepository implements ValidationRepository {
     public Flux<Validation> findAll(String status, String search, int page, int size) {
         int p = Math.max(0, page);
         int s = Math.max(1, size);
-        Specification<SubtypeValidationEntity> spec = Specification.where(null);
+        Specification<SubtypeValidationEntity> spec = null;
         if (status != null) {
-            spec = spec.and((root, query, cb) -> cb.equal(root.get("status"), status));
+            Specification<SubtypeValidationEntity> statusSpec = (root, query, cb) -> cb.equal(root.get("status"), status);
+            spec = Specification.where(statusSpec);
         }
         if (search != null) {
             String like = "%" + search.toUpperCase() + "%";
-            spec = spec.and((root, query, cb) -> cb.or(
+            Specification<SubtypeValidationEntity> searchSpec = (root, query, cb) -> cb.or(
                     cb.like(cb.upper(root.get("code")), like),
                     cb.like(cb.upper(root.get("description")), like)
-            ));
+            );
+            spec = spec == null ? Specification.where(searchSpec) : spec.and(searchSpec);
         }
         Specification<SubtypeValidationEntity> finalSpec = spec;
         return blockingExecutor.flux(() -> {

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaAgencyRepositoryTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaAgencyRepositoryTest.java
@@ -1,0 +1,68 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.agency.Agency;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa.entity.AgencyEntity;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa.entity.AgencyEntityId;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa.repository.AgencyJpaRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingExecutor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(BlockingExecutor.class)
+class JpaAgencyRepositoryTest {
+
+    @Autowired
+    private AgencyJpaRepository jpaRepository;
+
+    @Autowired
+    private BlockingExecutor blockingExecutor;
+
+    private JpaAgencyRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new JpaAgencyRepository(jpaRepository, blockingExecutor);
+    }
+
+    @Test
+    void findAllWithSubtypeFilterReturnsOnlyMatchingAgencies() {
+        AgencyEntity subtypeA = new AgencyEntity();
+        subtypeA.setId(new AgencyEntityId("SUB", "AG1"));
+        subtypeA.setName("Agency One");
+        subtypeA.setStatus("A");
+        subtypeA.setCreatedAt(OffsetDateTime.now());
+        subtypeA.setUpdatedAt(OffsetDateTime.now());
+        subtypeA.setUpdatedBy("tester");
+
+        AgencyEntity subtypeB = new AgencyEntity();
+        subtypeB.setId(new AgencyEntityId("OTHER", "AG2"));
+        subtypeB.setName("Agency Two");
+        subtypeB.setStatus("A");
+        subtypeB.setCreatedAt(OffsetDateTime.now());
+        subtypeB.setUpdatedAt(OffsetDateTime.now());
+        subtypeB.setUpdatedBy("tester");
+
+        jpaRepository.save(subtypeA);
+        jpaRepository.save(subtypeB);
+
+        List<Agency> results = repository.findAll("SUB", null, null, 0, 10)
+                .collectList()
+                .block();
+
+        assertThat(results)
+                .extracting(Agency::subtypeCode)
+                .containsOnly("SUB");
+        assertThat(results)
+                .extracting(Agency::agencyCode)
+                .containsExactly("AG1");
+    }
+}

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaCommercePlanRepositoryTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaCommercePlanRepositoryTest.java
@@ -1,0 +1,70 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.plan.CommercePlan;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.plan.CommerceValidationMode;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa.entity.CommercePlanEntity;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa.repository.CommercePlanJpaRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingExecutor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(BlockingExecutor.class)
+class JpaCommercePlanRepositoryTest {
+
+    @Autowired
+    private CommercePlanJpaRepository jpaRepository;
+
+    @Autowired
+    private BlockingExecutor blockingExecutor;
+
+    private JpaCommercePlanRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new JpaCommercePlanRepository(jpaRepository, blockingExecutor);
+    }
+
+    @Test
+    void findAllWithStatusFilterReturnsOnlyMatchingPlans() {
+        CommercePlanEntity active = new CommercePlanEntity();
+        active.setPlanCode("PLAN-A");
+        active.setPlanName("Plan Active");
+        active.setValidationMode(CommerceValidationMode.MERCHANT_ID);
+        active.setDescription("Active plan");
+        active.setStatus("A");
+        active.setCreatedAt(OffsetDateTime.now());
+        active.setUpdatedAt(OffsetDateTime.now());
+
+        CommercePlanEntity inactive = new CommercePlanEntity();
+        inactive.setPlanCode("PLAN-I");
+        inactive.setPlanName("Plan Inactive");
+        inactive.setValidationMode(CommerceValidationMode.MCC);
+        inactive.setDescription("Inactive plan");
+        inactive.setStatus("I");
+        inactive.setCreatedAt(OffsetDateTime.now());
+        inactive.setUpdatedAt(OffsetDateTime.now());
+
+        jpaRepository.save(active);
+        jpaRepository.save(inactive);
+
+        List<CommercePlan> results = repository.findAll("A", null, 0, 10)
+                .collectList()
+                .block();
+
+        assertThat(results)
+                .extracting(CommercePlan::status)
+                .containsOnly("A");
+        assertThat(results)
+                .extracting(CommercePlan::code)
+                .containsExactly("PLAN-A");
+    }
+}

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaSubtypeRepositoryTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaSubtypeRepositoryTest.java
@@ -1,0 +1,80 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.subtype.Subtype;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa.entity.SubtypeEntity;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa.entity.SubtypeEntityId;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa.repository.SubtypeJpaRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingExecutor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(BlockingExecutor.class)
+class JpaSubtypeRepositoryTest {
+
+    @Autowired
+    private SubtypeJpaRepository jpaRepository;
+
+    @Autowired
+    private BlockingExecutor blockingExecutor;
+
+    private JpaSubtypeRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new JpaSubtypeRepository(jpaRepository, blockingExecutor);
+    }
+
+    @Test
+    void findAllWithBinFilterReturnsOnlyMatchingSubtypes() {
+        SubtypeEntity first = new SubtypeEntity();
+        first.setId(new SubtypeEntityId("123456", "001"));
+        first.setName("Subtype One");
+        first.setDescription("Subtype for bin 123456");
+        first.setStatus("A");
+        first.setOwnerIdType("CC");
+        first.setOwnerIdNumber("123456789");
+        first.setBinExt(null);
+        first.setBinEfectivo("123456");
+        first.setSubtypeId(1L);
+        first.setCreatedAt(OffsetDateTime.now());
+        first.setUpdatedAt(OffsetDateTime.now());
+        first.setUpdatedBy("tester");
+
+        SubtypeEntity second = new SubtypeEntity();
+        second.setId(new SubtypeEntityId("654321", "002"));
+        second.setName("Subtype Two");
+        second.setDescription("Subtype for bin 654321");
+        second.setStatus("A");
+        second.setOwnerIdType("CC");
+        second.setOwnerIdNumber("987654321");
+        second.setBinExt(null);
+        second.setBinEfectivo("654321");
+        second.setSubtypeId(2L);
+        second.setCreatedAt(OffsetDateTime.now());
+        second.setUpdatedAt(OffsetDateTime.now());
+        second.setUpdatedBy("tester");
+
+        jpaRepository.save(first);
+        jpaRepository.save(second);
+
+        List<Subtype> results = repository.findAll("123456", null, null, 0, 10)
+                .collectList()
+                .block();
+
+        assertThat(results)
+                .extracting(Subtype::bin)
+                .containsOnly("123456");
+        assertThat(results)
+                .extracting(Subtype::subtypeCode)
+                .containsExactly("001");
+    }
+}

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaValidationMapRepositoryTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaValidationMapRepositoryTest.java
@@ -1,0 +1,69 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.rule.ValidationMap;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa.entity.SubtypeValidationMapEntity;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa.repository.SubtypeValidationMapJpaRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingExecutor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(BlockingExecutor.class)
+class JpaValidationMapRepositoryTest {
+
+    @Autowired
+    private SubtypeValidationMapJpaRepository jpaRepository;
+
+    @Autowired
+    private BlockingExecutor blockingExecutor;
+
+    private JpaValidationMapRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new JpaValidationMapRepository(jpaRepository, blockingExecutor);
+    }
+
+    @Test
+    void findAllWithSubtypeFilterReturnsOnlyMatchingValidationMaps() {
+        SubtypeValidationMapEntity first = new SubtypeValidationMapEntity();
+        first.setSubtypeCode("SUB");
+        first.setBin("123456");
+        first.setValidationId(1L);
+        first.setStatus("A");
+        first.setCreatedAt(OffsetDateTime.now());
+        first.setUpdatedAt(OffsetDateTime.now());
+        first.setUpdatedBy("tester");
+
+        SubtypeValidationMapEntity second = new SubtypeValidationMapEntity();
+        second.setSubtypeCode("OTHER");
+        second.setBin("123456");
+        second.setValidationId(2L);
+        second.setStatus("A");
+        second.setCreatedAt(OffsetDateTime.now());
+        second.setUpdatedAt(OffsetDateTime.now());
+        second.setUpdatedBy("tester");
+
+        jpaRepository.save(first);
+        jpaRepository.save(second);
+
+        List<ValidationMap> results = repository.findAll("SUB", null, null, 0, 10)
+                .collectList()
+                .block();
+
+        assertThat(results)
+                .extracting(ValidationMap::subtypeCode)
+                .containsOnly("SUB");
+        assertThat(results)
+                .extracting(ValidationMap::validationId)
+                .containsExactly(1L);
+    }
+}

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaValidationRepositoryTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaValidationRepositoryTest.java
@@ -1,0 +1,68 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.rule.Validation;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.rule.ValidationDataType;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa.entity.SubtypeValidationEntity;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.port.outbound.jpa.repository.SubtypeValidationJpaRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.util.BlockingExecutor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(BlockingExecutor.class)
+class JpaValidationRepositoryTest {
+
+    @Autowired
+    private SubtypeValidationJpaRepository jpaRepository;
+
+    @Autowired
+    private BlockingExecutor blockingExecutor;
+
+    private JpaValidationRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new JpaValidationRepository(jpaRepository, blockingExecutor);
+    }
+
+    @Test
+    void findAllWithStatusFilterReturnsOnlyActiveValidations() {
+        SubtypeValidationEntity active = new SubtypeValidationEntity();
+        active.setCode("VAL-A");
+        active.setDescription("Active validation");
+        active.setDataType(ValidationDataType.TEXT);
+        active.setStatus("A");
+        active.setCreatedAt(OffsetDateTime.now());
+        active.setUpdatedAt(OffsetDateTime.now());
+
+        SubtypeValidationEntity inactive = new SubtypeValidationEntity();
+        inactive.setCode("VAL-I");
+        inactive.setDescription("Inactive validation");
+        inactive.setDataType(ValidationDataType.TEXT);
+        inactive.setStatus("I");
+        inactive.setCreatedAt(OffsetDateTime.now());
+        inactive.setUpdatedAt(OffsetDateTime.now());
+
+        jpaRepository.save(active);
+        jpaRepository.save(inactive);
+
+        List<Validation> results = repository.findAll("A", null, 0, 10)
+                .collectList()
+                .block();
+
+        assertThat(results)
+                .extracting(Validation::status)
+                .containsOnly("A");
+        assertThat(results)
+                .extracting(Validation::code)
+                .containsExactly("VAL-A");
+    }
+}


### PR DESCRIPTION
## Summary
- guard repository Specification chains so the first filter initializes with Specification.where before chaining
- add an in-memory database dependency and repository tests that exercise each findAll with a single filter

## Testing
- mvn test *(fails: unable to download Spring Boot parent POM from Maven Central in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e024cc83f4832e851fe38ca77fc575